### PR TITLE
Fix remote code execution #1

### DIFF
--- a/html/delete.php
+++ b/html/delete.php
@@ -1,5 +1,5 @@
 <?php
-$file = $_GET["delete"];
+$file = escapeshellarg($_GET["delete"]);
 shell_exec("rm /home/ccdadmin/upload/$file");
 header("location:/file.php");
 ?>


### PR DESCRIPTION
The 'delete' parameter is being passed to shell_exec without being sanitized, thus leading to remote code execution.

To execute the `id` command, I would send a request like the following:
```
GET /delete.php?delete=;id
```

Always clean user inputs before passing to shells and such.